### PR TITLE
Use main project mongoose

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,18 @@ let Task = db.model('Task', schema);
 To convert the Task model into a crontab collection, attach the plugin, create a cron worker instance, then call the `start` method on it to start processing.
 
 ```js
-import {cronPlugin} from 'mongoose-cron';
+import mongoose from 'mongoose';
+import MongooseCronFactory from 'mongoose-cron';
+const cronPlugin = MongooseCronFactory(mongoose);
+/**
+ * In alternative of the import and the definition of cronPlugin variable,
+ * you can use this compact one-line solution:
+ *
+ *  const cronPlugin = require('mongoose-cron')(mongoose);
+ **/
 
 let schema = new mongoose.Schema({name: String});
+
 schema.plugin(cronPlugin, {
   handler: doc => console.log('processing', doc) // function or promise
 });

--- a/example/index.js
+++ b/example/index.js
@@ -1,51 +1,70 @@
-'use strict';
+"use strict";
 
 /* initializing mongodb */
 
-const mongoose = require('mongoose');
-const dbhost = process.env.DB_HOST || 'localhost:27017';
-const dbname = process.env.DB_NAME || 'testdb';
-const db = mongoose.connect(`mongodb://${dbhost}/${dbname}`);
+const mongoose = require("mongoose");
+const dbhost = process.env.DB_HOST || "localhost:27017";
+const dbname = process.env.DB_NAME || "testdb";
 
-/* defining polymorphic model with support for cron */
+mongoose.connect(`mongodb://${dbhost}/${dbname}`).then((db) => {
+  /* defining polymorphic model with support for cron */
 
-const {cronPlugin} = require('..');
+  const cronPlugin = require("..")(mongoose);
 
-let noteSchema = new mongoose.Schema({
-  name: {type: String}
+  let noteSchema = new mongoose.Schema({
+    name: { type: String }
+  });
+  let checklistSchema = new mongoose.Schema({
+    description: { type: String }
+  });
+  let reminderSchema = new mongoose.Schema({
+    description: { type: String }
+  });
+
+  noteSchema.plugin(cronPlugin, {
+    handler: doc => console.log("processing", doc.id)
+  });
+
+  let Note = db.model("Note", noteSchema);
+  let Checklist = Note.discriminator("Checklist", checklistSchema);
+  let Reminder = Note.discriminator("Reminder", reminderSchema);
+
+  /* creating cron worker and starting the heartbit */
+
+  let cron = Note.createCron().start();
+
+  /* sedding */
+
+  Checklist.findOneAndUpdate(
+    { _id: "565781bba17d0e685f8e2086" },
+    {
+      name: "Job 1",
+      description: "ignored by the cron heartbit"
+    },
+    { upsert: true, setDefaultsOnInsert: true, new: true }
+  )
+    .then(res => {})
+    .catch(console.log);
+
+  Reminder.findOneAndUpdate(
+    { _id: "565781bba17d0e685f8e2087" },
+    {
+      name: "Job 2",
+      description: "remined me every 1s",
+      cron: {
+        enabled: true,
+        startAt: new Date(),
+        interval: "* * * * * *"
+      }
+    },
+    { upsert: true, setDefaultsOnInsert: true, new: true }
+  )
+    .then(res => {})
+    .catch(console.log);
+
+  // Auto stop cron after 1 minute
+  setTimeout(() => {
+    cron.stop();
+  }, 60000)
+  
 });
-let checklistSchema = new mongoose.Schema({
-  description: {type: String}
-});
-let reminderSchema = new mongoose.Schema({
-  description: {type: String}
-});
-
-noteSchema.plugin(cronPlugin, {
-  handler: doc => console.log('processing', doc.id)
-});
-
-let Note = db.model('Note', noteSchema);
-let Checklist = Note.discriminator('Checklist', checklistSchema);
-let Reminder = Note.discriminator('Reminder', reminderSchema);
-
-/* creating cron worker and starting the heartbit */
-
-let cron = Note.createCron().start();
-
-/* sedding */
-
-Checklist.findOneAndUpdate({_id: '565781bba17d0e685f8e2086'}, {
-  name: 'Job 1',
-  description: 'ignored by the cron heartbit'
-}, {upsert: true, setDefaultsOnInsert: true, new: true}).then(res => {}).catch(console.log);
-
-Reminder.findOneAndUpdate({_id: '565781bba17d0e685f8e2087'}, {
-  name: 'Job 2',
-  description: 'remined me every 1s',
-  cron: {
-    enabled: true,
-    startAt: new Date(),
-    interval: '* * * * * *'
-  }
-}, {upsert: true, setDefaultsOnInsert: true, new: true}).then(res => {}).catch(console.log);

--- a/example/package.json
+++ b/example/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "mongoose-cron",
-  "version": "0.5.7",
-  "description": "MongoDB collection as crontab",
+  "name": "mongoose-cron-example",
+  "version": "0.0.1",
+  "description": "Example of using mongoose-cron",
   "main": "index.js",
   "scripts": {
-    "example": "cd example && npm install && node index.js",
+    "start": "node --harmony --harmony-destructuring index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -35,6 +35,7 @@
   "devDependencies": {},
   "dependencies": {
     "later": "^1.2.0",
-    "moment": "^2.15.1"
+    "moment": "^2.15.1",
+    "mongoose": "^5.9.5"
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports.cronPlugin = require('./lib/plugin');
+module.exports = require('./lib/plugin');

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,48 +1,64 @@
-'use strict';
+"use strict";
+const Cron = require("./cron");
 
-const mongoose = require('mongoose');
-const Cron = require('./cron');
+module.exports = function MongooseCronFactory(mongoose) {
+  
+  return function(schema, options) {
+    if (!options) options = {};
 
-module.exports = function(schema, options) {
-  if (!options) options = {};
+    schema.add({
+      cron: new mongoose.Schema(
+        {
+          enabled: {
+            // on/off switch
+            type: Boolean
+          },
+          startAt: {
+            // first possible start date
+            type: Date
+          },
+          stopAt: {
+            // last possible start date (`null` if not recurring)
+            type: Date
+          },
+          interval: {
+            // cron string interval (e.g. `* * * * * *`)
+            type: String
+          },
+          removeExpired: {
+            // set to `true` for the expired jobs to be automatically deleted
+            type: Boolean
+          },
+          startedAt: {
+            // (automatic) set every time a job processing starts
+            type: Date
+          },
+          processedAt: {
+            // (automatic) set every time a job processing ends
+            type: Date
+          },
+          locked: {
+            // (automatic) `true` when job is processing
+            type: Boolean
+          },
+          lastError: {
+            // (automatic) last error message
+            type: String
+          }
+        },
+        { _id: false }
+      )
+    });
 
-  schema.add({
-    cron: new mongoose.Schema({
-      enabled: { // on/off switch
-        type: Boolean
-      },
-      startAt: { // first possible start date
-        type: Date
-      },
-      stopAt: { // last possible start date (`null` if not recurring)
-        type: Date
-      },
-      interval: { // cron string interval (e.g. `* * * * * *`)
-        type: String
-      },
-      removeExpired: { // set to `true` for the expired jobs to be automatically deleted
-        type: Boolean
-      },
-      startedAt: { // (automatic) set every time a job processing starts
-        type: Date
-      },
-      processedAt: { // (automatic) set every time a job processing ends
-        type: Date
-      },
-      locked: { // (automatic) `true` when job is processing
-        type: Boolean
-      },
-      lastError: { // (automatic) last error message
-        type: String
-      }
-    }, {_id: false})
-  });
+    schema.index({
+      "cron.enabled": 1,
+      "cron.locked": 1,
+      "cron.startAt": 1,
+      "cron.stopAt": 1
+    });
 
-  schema.index(
-    {'cron.enabled': 1, 'cron.locked': 1, 'cron.startAt': 1, 'cron.stopAt': 1}
-  );
-
-  schema.statics.createCron = function(config) {
-    return new Cron(this, Object.assign({}, options, config));
+    schema.statics.createCron = function(config) {
+      return new Cron(this, Object.assign({}, options, config));
+    };
   };
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "MongoDB collection as crontab",
   "main": "index.js",
   "scripts": {
-    "example": "cd example && npm install && node index.js",
+    "example": "npm install && cd example && npm install && node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
   "homepage": "https://github.com/xpepermint/mongoose-cron#readme",
   "devDependencies": {},
   "dependencies": {
-    "later": "1.2.0",
-    "moment": "2.15.1",
-    "mongoose": "4.6.1"
+    "later": "^1.2.0",
+    "moment": "^2.15.1"
   }
 }


### PR DESCRIPTION
I made some modifiation to passing from outside the version of mongoose, this because, the current version of the project fixes the mongoose version to an old version that it's not compatible with newest one.
This edit, affect only the style of import of the lib into an existing project, i edit documentation (readme.md) and example and someting into package.json.

I made this because i need this very good library in my project and i need to use mongose version newer than 4.x.x

I don't modify main lib package.json version